### PR TITLE
Fix to incorrect version comparisons

### DIFF
--- a/tests/test_mappingrules.py
+++ b/tests/test_mappingrules.py
@@ -24,9 +24,15 @@ def get_latest_omop_ddl():
     for file in sql_files:
         match = re.search(r'OMOPCDM_postgresql_(\d+\.\d+)_ddl\.sql', file.name)
         if match:
-            versions.append((float(match.group(1)), file))
+            #versions.append(match.group(1).split('.'), file)
+            version = list(map(int, (match.group(1).split('.'))))
+            version.append(file)
+            versions.append(version)
     # Return the file with highest version
-    return max(versions, key=lambda x: x[0])[1]
+    max_version = max(versions, key=lambda x: (x[0], x[1]))
+        
+    return max_version[2]
+    
 
 
 


### PR DESCRIPTION
Fixes incorrect version comparisons by splitting the version string and comparing the components as ints.

| <!-- # Delete content types that don't apply to your pull request -->|
|-|
🦋 Bug Fix

## PR Description
Fixes incorrect version comparison in test,

## Related Issues or other material
Closes #51 

## Screenshots, example outputs/behaviour etc.

## ✅ Added/updated tests?
- [x] This PR contains relevant tests / Or doesn't need to per the below explanation

Doesn't need a test - it is a fix to the tests.