### PR TITLE
Fix for paths in alias

### DIFF
--- a/carrottransform/tools/file_helpers.py
+++ b/carrottransform/tools/file_helpers.py
@@ -35,6 +35,10 @@ def resolve_paths(args: List[Optional[Path]]) -> List[Optional[Path]]:
     # Handle None values and replace @carrot with the actual package path
     prefix = '@carrot'
     return [
-        package_path / Path(str(arg).replace(prefix, '').lstrip('/')) if arg is not None and str(arg).startswith(prefix) else arg 
+<<<<<<< HEAD
+        package_path / Path(str(arg).replace(prefix, '').replace('\\', '/').lstrip('/')) if arg is not None and str(arg).startswith(prefix) else arg 
+=======
+        package_path / Path(str(arg).replace(prefix, '').lstrip('/\\')) if arg is not None and str(arg).startswith(prefix) else arg 
+>>>>>>> origin/54-carrot-doesnt-work-on-windows
         for arg in args
     ]

--- a/tests/test_file_helpers.py
+++ b/tests/test_file_helpers.py
@@ -56,4 +56,30 @@ def test_resolve_paths_all_none():
 @pytest.mark.unit
 def test_resolve_paths_empty_list():
     """Test handling empty list"""
-    assert resolve_paths([]) == [] 
+    assert resolve_paths([]) == []
+
+@pytest.mark.unit
+def test_resolve_paths_windows():
+    """Test resolving @carrot paths on Windows"""
+    try:
+        package_path = (resources.files('carrottransform') / '__init__.py').parent
+    except Exception:
+        import carrottransform
+        package_path = Path(carrottransform.__file__).resolve().parent
+    
+    test_paths = [
+        '@carrot\\config\\test.json',  # Windows backslash
+        '@carrot/config\\test.json',   # Mixed slashes
+        '@carrot\\config/test.json'    # Mixed slashes
+    ]
+    expected = [package_path / 'config/test.json']
+    
+    results = resolve_paths(test_paths)
+<<<<<<< HEAD
+    print("\nExpected:", expected[0])
+    print("Results:")
+    for r in results:
+        print(r)
+=======
+>>>>>>> origin/54-carrot-doesnt-work-on-windows
+    assert all(r == expected[0] for r in results) 


### PR DESCRIPTION
Should fix the alias @carrot for windows file paths, and provide test for the windows filepaths.

| <!-- # Delete content types that don't apply to your pull request -->|
|-|
🦋 Bug Fix


## PR Description
Should fix the windows path issue with the @carrot alias. Adds tests for the same.

## Related Issues or other material
Closes #54 

## Screenshots, example outputs/behaviour etc.

## ✅ Added/updated tests?
- [x] This PR contains relevant tests / Or doesn't need to per the below explanation

## [optional] What gif best describes this PR or how it makes you feel?
![Windows fail](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExYjI5anVqMnkwaWs3eW92dDZ6Mnk3NTN5aHI2aDFzeGx3NGw3NDZyNiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/mq5y2jHRCAqMo/giphy.gif)
