### PR TITLE
corrects saved_person_id_file to have newlines

### DIFF
--- a/carrottransform/cli/subcommands/run.py
+++ b/carrottransform/cli/subcommands/run.py
@@ -194,7 +194,7 @@ def mapstream(
             fhpout.write("SOURCE_SUBJECT\tTARGET_SUBJECT\n")
             ##iterate through the ids and write them to the file.
             for person_id, person_assigned_id in person_lookup.items():
-                fhpout.write(f"{str(person_id)}\t{str(person_assigned_id)}")
+                fhpout.write(f"{str(person_id)}\t{str(person_assigned_id)}\n")
 
         ## Initialise output files (adding them to a dict), output a header for each
         ## these aren't being closed deliberately


### PR DESCRIPTION
the file needs a newline after each record

| <!-- # Delete content types that don't apply to your pull request -->|
|-|
🦋 Bug Fix

## PR Description

adds a newline that's needed for correct person id file output

## Related Issues or other material
Closes #64

## Screenshots, example outputs/behaviour etc.

## ✅ Added/updated tests?
- [x] This PR contains relevant tests / Or doesn't need to per the below explanation

## [optional] What gif best describes this PR or how it makes you feel?
![alt_text](gif_link)
