### PR TITLE
Fix Repo owner case mismatch

### DIFF
--- a/.github/workflows/release.versioned.yml
+++ b/.github/workflows/release.versioned.yml
@@ -64,7 +64,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
-          images: ${{ env.registry }}/${{ env.repo-owner }}/${{ env.image-name }}
+          images: ${{ env.registry }}/${{ env.REPO_OWNER_LOWER }}/${{ env.image-name }}
           tags: | # new tags only
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}


### PR DESCRIPTION
🦋 Bug Fix
__
## PR Description
This PR fixes Docker image version tags not being applied.

Fix case mismatch in `release.versioned.yml` workflow that prevented version tags from being applied to Docker images. The docker/metadata-action was using mixed-case repo-owner (Health-Informatics-UoN) while tag-push-action used lowercase, causing image path mismatches.

## Related Issues or other material
Related #162
Closes #162

